### PR TITLE
Added Hue lights

### DIFF
--- a/devices/configuration.py
+++ b/devices/configuration.py
@@ -24,6 +24,7 @@ class Configuration(metaclass=Singleton):
     STD_UNIT_SMARTPLUG_START_STATE = 100  # Begin counting for SmartPlugs State
     STD_UNIT_SMARTPLUG_START_USAGE = 120  # Begin counting for SmartPlugs Usage
     STD_UNIT_SMARTPLUG_START_KWH = 140    # Begin counting for SmartPlugs kWh
+    STD_UNIT_LIGHT_START_STATE = 200 # Begin counting for Light State
 
     STR_UNIT_POWER = "Power usage"
     STR_UNIT_GAS = "Gas usage"

--- a/devices/device_factory.py
+++ b/devices/device_factory.py
@@ -14,6 +14,7 @@ from devices.thermostat_state import DeviceThermostatState
 from devices.smartplug import DeviceSmartPlugState
 from devices.smartplug import DeviceSmartPlugUsage
 from devices.smartplug import DeviceSmartPlugkWh
+from devices.lights import DeviceLightState
 
 
 class DeviceFactory:
@@ -41,5 +42,9 @@ class DeviceFactory:
             container.add_device(DeviceSmartPlugState(plugin_devices, toon, plug).create(plug))
             container.add_device(DeviceSmartPlugUsage(plugin_devices, toon, plug).create(plug))
             container.add_device(DeviceSmartPlugkWh(plugin_devices, toon, plug).create(plug))
+
+        # Lights
+        for light in toon.lights:
+            container.add_device(DeviceLightState(plugin_devices, toon, light).create(light))
 
         return container

--- a/devices/lights.py
+++ b/devices/lights.py
@@ -1,0 +1,86 @@
+import Domoticz
+from devices.configuration import config
+from devices.device import Device
+from devices.device import DeviceCreateException
+from devices.device import DeviceCommandException
+from devices.device import DeviceUpdateException
+
+
+
+
+class DeviceLightState(Device):
+    domoticz_device_type = 244
+    domoticz_subtype = 73
+    domoticz_switch_type = 0
+    domoticz_image = 0
+    _huelight = None
+
+    def __init__(self, plugin_devices, toon, light):
+        self._huelight = light
+        super().__init__(self._huelight.name,
+                         config.STD_UNIT_LIGHT_START_STATE + self._huelight.zwave_index,
+                         plugin_devices,
+                         toon)
+
+    def create(self, light):
+        if not self.exists:
+            try:
+                Domoticz.Log("Creating HueLight '" + self.name + "'")
+                Domoticz.Device(Name=self.name, Unit=self.unit, Type=self.domoticz_device_type,
+                                Subtype=self.domoticz_subtype, Switchtype=self.domoticz_switch_type,
+                                Image=self.domoticz_image).Create()
+
+            except DeviceCreateException as ex:
+                Domoticz.Log("An error occurred creating HueLight '" + self.name + "'")
+                Domoticz.Log("Exception: " + str(ex))
+        elif config.debug:
+            Domoticz.Log("Unit " + str(self.unit) + " exists - nothing to do")
+        return self
+
+    def on_command(self, unit, command, level, hue):
+        try:
+            str_program_state = str(command).lower()
+
+            # Only of HueLight is Unlocked (Configured in Toon) we can switch it On/Off
+            if not self._huelight.is_locked:
+                if str_program_state == "on":
+                    # Turn HueLight On
+                    self._huelight.turn_on()
+                    program_state = 1
+                else:
+                    # Turn HueLight Off
+                    self._huelight.turn_off()
+                    program_state = 0
+
+                if config.debug:
+                    Domoticz.Log("Set HueLight '" + self.name + "' State :" + str_program_state)
+
+                # Call Update
+                self.plugin_devices[self.unit].Update(program_state, str(program_state))
+
+            else:
+                Domoticz.Log("Can't switch state of HueLight '" + self.name + "'. It is Locked in Toon")
+
+        except DeviceCommandException as ex:
+            Domoticz.Log("An error occurred Setting HueLight '" + self.name + "'")
+            Domoticz.Log("Exception: " + str(ex))
+
+    def update(self):
+        super().update()
+        str_value = ""
+
+        try:
+            program_state = 1 if (self._huelight.status.lower() == "on") else 0
+            str_value = str(program_state)
+
+            if str_value != self.previous_value:
+                if config.debug:
+                    Domoticz.Log("HueLight '" + self.name + "' state changed, update: " + str_value)
+                self.plugin_devices[self.unit].Update(program_state, str_value)
+
+        except DeviceUpdateException as ex:
+            Domoticz.Log("An error occurred Updating HueLight '" + self.name + "'")
+            Domoticz.Log("Exception: " + str(ex))
+
+        self.set_previous_value(str_value)
+        


### PR DESCRIPTION
This PR adds the Hue Lights you might have on your Toon.
The code is based on the SmartPlug work from @tne7laa .

I have addes this for fun and to learn more about how all this works, but in my opinion the build in Hue support from Domoticz is a lot better (and works fine, also when you have the lights on Hue, Toon and Domoticz). So only merge if you think there is use for it.

The only thing we can do with Hue lights via the toonapilib is turning them on or off, no color changing, no dimming...